### PR TITLE
Support for SQL full text search

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ This package is supported on Umbraco 7.5+.
 FindAndReplace is available from Our Umbraco, NuGet, or as a manual download directly from GitHub.
 
 #### Our Umbraco repository
+
 You can find a downloadable package, along with a discussion forum for this package, on the [Our Umbraco](https://our.umbraco.org/projects/backoffice-extensions/find-and-replace/) site.
 
 #### NuGet package repository
+
 To [install from NuGet](https://www.nuget.org/packages/Cogworks.FindAndReplace/), run the following command in your instance of Visual Studio.
 
     PM> Install-Package Cogworks.FindAndReplace
@@ -33,6 +35,49 @@ To use it you have to right click on content tree node and choose "Find And Repl
 ![Meganav Property Editor](docs/img/replace-all.gif?raw=true)
 
 You are able to replace each occursion exclusively or replace all of those using "Replace all" button.
+
+## Enable Full Text search
+
+For large Umbraco sites with lots of content - search and replace can be slow and cause SQL timeouts. Full text search can help out here. Currently only one language is supported here - so this won't work for multi lingual sites right now.
+
+In your SQL database run the following:
+
+```
+select * from sys.fulltext_languages
+```
+
+This will give you a list of supported languages and IDs. English is ID 1033 - but can be replaced with your language of choice below.
+
+To enable full text indexing of the Umbraco content - run the following SQL against the database.
+
+```
+CREATE FULLTEXT CATALOG UmbracoFullTextCatalogue;
+
+CREATE FULLTEXT INDEX ON CmsPropertyData
+(  
+    dataNvarchar, dataNText                         
+        Language 1033                 
+)  
+    KEY INDEX PK_cmsPropertyData  
+    ON UmbracoFullTextCatalogue;
+	
+ALTER FULLTEXT INDEX ON CmsPropertyData  
+   START FULL POPULATION;  
+
+ALTER FULLTEXT INDEX ON CmsPropertyData SET CHANGE_TRACKING AUTO;  
+
+
+CREATE FULLTEXT INDEX ON UmbracoNode
+(  
+    Path							 
+        Language 1033                  
+)  
+KEY INDEX PK_structure  
+ON UmbracoFullTextCatalogue;
+```
+
+Lastly add an apsetting "FindAndReplace:EnableFullTextSearch" in your Web.config with a value of "True"
+
 
 ### Contribution guidelines
 

--- a/src/Cogworks.FindAndReplace/Application/FindAndReplaceApplicationEventHandler.cs
+++ b/src/Cogworks.FindAndReplace/Application/FindAndReplaceApplicationEventHandler.cs
@@ -1,0 +1,20 @@
+﻿using System.Web.Configuration;
+using Umbraco.Core;
+
+namespace Cogworks.FindAndReplace.Application
+{
+    public class FindAndReplaceApplicationEventHandler : ApplicationEventHandler
+    {
+
+        protected override void ApplicationStarting(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+
+        {
+            bool enableFullTextSearch;
+            bool.TryParse(WebConfigurationManager.AppSettings["FindAndReplace:EnableFullTextSearch"], out enableFullTextSearch);
+
+            FindAndReplaceContext.Instance.EnableFullTextSearch = enableFullTextSearch;
+
+        }
+
+    }
+}

--- a/src/Cogworks.FindAndReplace/Application/FindAndReplaceContext.cs
+++ b/src/Cogworks.FindAndReplace/Application/FindAndReplaceContext.cs
@@ -1,0 +1,27 @@
+﻿namespace Cogworks.FindAndReplace.Application
+{
+    class FindAndReplaceContext
+    {
+
+        private static readonly FindAndReplaceContext instance = new FindAndReplaceContext();
+
+        static FindAndReplaceContext()
+        {
+        }
+
+        private FindAndReplaceContext()
+        {
+        }
+
+        public static FindAndReplaceContext Instance
+        {
+            get
+            {
+                return instance;
+            }
+        }
+
+        public bool EnableFullTextSearch { get; set; }
+
+    }
+}

--- a/src/Cogworks.FindAndReplace/Cogworks.FindAndReplace.csproj
+++ b/src/Cogworks.FindAndReplace/Cogworks.FindAndReplace.csproj
@@ -259,6 +259,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Application\FindAndReplaceApplicationEventHandler.cs" />
+    <Compile Include="Application\FindAndReplaceContext.cs" />
     <Compile Include="Models\ContentDataModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Web\App_Start\FindAndReplaceApplicationEventHandler.cs" />

--- a/src/Cogworks.FindAndReplace/Properties/AssemblyInfo.cs
+++ b/src/Cogworks.FindAndReplace/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.1.1")]
+[assembly: AssemblyFileVersion("1.0.1.1")]

--- a/src/Cogworks.FindAndReplace/Properties/AssemblyInfo.cs
+++ b/src/Cogworks.FindAndReplace/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.1")]
-[assembly: AssemblyFileVersion("1.0.1.1")]
+[assembly: AssemblyVersion("1.0.1.3")]
+[assembly: AssemblyFileVersion("1.0.1.3")]

--- a/src/Cogworks.FindAndReplace/Web/Controllers/API/FindAndReplaceAPIController.cs
+++ b/src/Cogworks.FindAndReplace/Web/Controllers/API/FindAndReplaceAPIController.cs
@@ -52,11 +52,14 @@ namespace Cogworks.FindAndReplace.Web.Controllers.API
             } 
             else
             {
+                
+                string contentPath = contentId < 0 ? contentId + ",%" : "%," + contentId + "%";
+
                 var queryParamsObj = new
                 {
                     phrase = phrase,
                     contentId = contentId.ToString(),
-                    contentPath = "," + contentId
+                    contentPath = contentPath
                 };
 
                 string query = @"SELECT cpt.Alias as PropertyAlias, cpd.dataNvarchar, cpd.dataNtext, cd.nodeId as ContentId, un.text as NodeName
@@ -64,7 +67,7 @@ namespace Cogworks.FindAndReplace.Web.Controllers.API
                 LEFT JOIN cmsDocument cd ON cpd.versionId = cd.versionId
                 LEFT JOIN umbracoNode un ON cpd.contentNodeId = un.id
                 LEFT JOIN cmsPropertyType cpt ON cpd.propertytypeid = cpt.Id
-                WHERE(Contains(cpd.dataNtext, @phrase) OR Contains(cpd.dataNvarchar, @phrase))
+                WHERE(FREETEXT(cpd.dataNtext, @phrase) OR FREETEXT(cpd.dataNvarchar, @phrase))
                 AND cd.published = 1
                 AND Contains(un.path, @contentId)
                 AND un.path LIKE @contentPath


### PR DESCRIPTION
For large Umbraco sites with lots of content - search and replace can be slow and cause SQL timeouts. Full text search can help out here. Currently only one language is supported here - so this won't work for multi lingual sites right now.

In your SQL database run the following:

```
select * from sys.fulltext_languages
```

This will give you a list of supported languages and IDs. English is ID 1033 - but can be replaced with your language of choice below.

To enable full text indexing of the Umbraco content - run the following SQL against the database.

```
CREATE FULLTEXT CATALOG UmbracoFullTextCatalogue;

CREATE FULLTEXT INDEX ON CmsPropertyData
(  
    dataNvarchar, dataNText                         
        Language 1033                 
)  
    KEY INDEX PK_cmsPropertyData  
    ON UmbracoFullTextCatalogue;
	
ALTER FULLTEXT INDEX ON CmsPropertyData  
   START FULL POPULATION;  

ALTER FULLTEXT INDEX ON CmsPropertyData SET CHANGE_TRACKING AUTO;  


CREATE FULLTEXT INDEX ON UmbracoNode
(  
    Path							 
        Language 1033                  
)  
KEY INDEX PK_structure  
ON UmbracoFullTextCatalogue;
```

Lastly add an apsetting "FindAndReplace:EnableFullTextSearch" in your Web.config with a value of "True"